### PR TITLE
Add multiple spring profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 .idea
 target
-client-secret.json
+*secret.json
 *.iml
 *.db
 *.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ notifications:
 before_install:
   # Decrypt credentials file to authorize with GCP
   - openssl aes-256-cbc -K $encrypted_a6a69c5b1756_key -iv $encrypted_a6a69c5b1756_iv -in client-secret.json.enc -out client-secret.json -d
+install:
+  # Use the maven 'prod' profile which installs specific dependencies and sets spring profile to 'prod'
+  - mvn -P prod install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+script:
+  - mvn -P prod test -B
 deploy:
   provider: gae
   project: moltimate

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ProMol successor's backend application.
 
 * [Setup & Run](#setup-run)
 * [Wiping Local Database](#wiping-local-database)
-* [API Summary](#api-summry)
+* [API Summary](#api-summary)
 * [API Details](#api-details)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,22 +25,27 @@
     </properties>
 
     <dependencies>
+        <!-- Spring Starters -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>2.0.6.RELEASE</version>
+        </dependency>
 
+        <!-- JPA/Hibernate -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-orm</artifactId>
@@ -54,23 +59,40 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>2.0.6.RELEASE</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.197</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <version>5.2.12.Final</version>
         </dependency>
 
+        <!-- Utilities -->
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>22.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>4.3.2</version>
+        </dependency>
+
+        <!-- Protein Function Analysis -->
         <dependency>
             <groupId>org.biojava</groupId>
             <artifactId>biojava-structure</artifactId>
@@ -82,32 +104,70 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.2</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.6</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>22.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
-            <version>4.3.2</version>
-        </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>Finchley.SR1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-gcp-dependencies</artifactId>
+                <version>1.0.0.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <profiles>
+        <!-- Local Development (H2 database) -->
+        <profile>
+            <id>dev</id>
+            <properties>
+                <activatedSpringProfile>dev</activatedSpringProfile>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                    <version>1.4.197</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Production Profile (connects to GCP Cloud SQL) -->
+        <profile>
+            <id>prod</id>
+            <properties>
+                <activatedSpringProfile>prod</activatedSpringProfile>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-gcp-starter</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>org.springframework.cloud</groupId>
+                    <artifactId>spring-cloud-gcp-starter-sql-mysql</artifactId>
+                    <version>1.1.0.RELEASE</version>
+                </dependency>
+                <dependency>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                    <version>8.0.14</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -116,5 +176,11 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 </project>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:./moltimate;DB_CLOSE_ON_EXIT=FALSE
+    username: root
+    password: password
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,16 @@
+spring:
+  cloud:
+    gcp:
+      project-id: moltimate
+      sql:
+        database-name: motifs
+        instance-connection-name: moltimate:us-east4:backend-db-sql
+        credentials:
+          location: file:cloud-sql-secret.json
+  datasource:
+    continue-on-error: true
+    initialization-mode: always
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.MySQL55Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,4 @@
+# This property comes from the activated Maven profile (assigned with `mvn -P profile-name`, defined in pom.xml)
 spring:
-  datasource:
-    url: jdbc:h2:./moltimate;DB_CLOSE_ON_EXIT=FALSE
-    username: root
-    password: password
-    driver-class-name: org.h2.Driver
-  h2:
-    console:
-      enabled: true
-      path: /h2
-  jpa:
-    hibernate:
-      ddl-auto: update
+  profiles:
+    active: @activatedSpringProfile@


### PR DESCRIPTION
This will add multiple spring and maven profiles which manage profile-specific dependencies for local development and production deployments.

The 'dev' profile is the default, so no changes are necessary to continue the usual local development. This will create a local H2 database.

The 'prod' profile is used to set up a connection to our GCP Cloud SQL database.