### PR TITLE
Add motif creation/decoding

### DIFF
--- a/src/main/java/org/moltimate/moltimatebackend/ServletInitializer.java
+++ b/src/main/java/org/moltimate/moltimatebackend/ServletInitializer.java
@@ -1,4 +1,6 @@
-package org.moltimate.moltimatebackend;/*
+package org.moltimate.moltimatebackend;
+
+/*
  * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +16,13 @@ package org.moltimate.moltimatebackend;/*
  * limitations under the License.
  */
 
-
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 
 public class ServletInitializer extends SpringBootServletInitializer {
 
-  @Override
-  protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-    return application.sources(Application.class);
-  }
-
+    @Override
+    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+        return application.sources(Application.class);
+    }
 }

--- a/src/main/java/org/moltimate/moltimatebackend/controller/AlignmentController.java
+++ b/src/main/java/org/moltimate/moltimatebackend/controller/AlignmentController.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.moltimate.moltimatebackend.dto.ActiveSiteAlignmentRequest;
 import org.moltimate.moltimatebackend.dto.ActiveSiteAlignmentResponse;
 import org.moltimate.moltimatebackend.service.AlignmentService;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidPdbIdException;
+import org.moltimate.moltimatebackend.exception.InvalidPdbIdException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +36,7 @@ public class AlignmentController {
     })
     @RequestMapping(value = "/activesite", method = RequestMethod.POST, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ActiveSiteAlignmentResponse> activeSiteAlignment(ActiveSiteAlignmentRequest alignmentRequest) {
-        log.info("Received dto to align active sites: " + alignmentRequest);
+        log.info("Received request to align active sites: " + alignmentRequest);
         return ResponseEntity.ok(alignmentService.alignActiveSites(alignmentRequest));
     }
 }

--- a/src/main/java/org/moltimate/moltimatebackend/controller/ControllerExceptionHandler.java
+++ b/src/main/java/org/moltimate/moltimatebackend/controller/ControllerExceptionHandler.java
@@ -1,9 +1,10 @@
 package org.moltimate.moltimatebackend.controller;
 
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidEcNumberException;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidFileException;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidMotifException;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidPdbIdException;
+import org.moltimate.moltimatebackend.exception.InvalidEcNumberException;
+import org.moltimate.moltimatebackend.exception.InvalidFileException;
+import org.moltimate.moltimatebackend.exception.InvalidMotifException;
+import org.moltimate.moltimatebackend.exception.InvalidPdbIdException;
+import org.moltimate.moltimatebackend.exception.MotifFileParseException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/org/moltimate/moltimatebackend/controller/FileController.java
+++ b/src/main/java/org/moltimate/moltimatebackend/controller/FileController.java
@@ -2,12 +2,12 @@ package org.moltimate.moltimatebackend.controller;
 
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
+import org.moltimate.moltimatebackend.dto.MakeMotifRequest;
 import org.moltimate.moltimatebackend.util.FileUtils;
 import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,68 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class FileController {
 
-    private static enum ProteinFileType {
-        PDB(".pdb"),
-        MMCIF(".cif"),
-        MOTIF(".motif");
-
-        private String fileExtension;
-
-        ProteinFileType(String fileExtension) {
-            this.fileExtension = fileExtension;
-        }
-
-        @Override
-        public String toString() {
-            return fileExtension;
-        }
-    }
-
-    @ApiOperation(value = "Download PDB")
+    /**
+     * Creates a new .motif file
+     */
+    @ApiOperation(value = "Creates a new .motif file")
     @RequestMapping(
-            path = "/pdb/{pdbId}",
-            method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_OCTET_STREAM_VALUE
-    )
-    public ResponseEntity<Resource> downloadAsPdb(@PathVariable String pdbId) {
-        return createResponseFile(
-                FileUtils.getPdbFile(pdbId),
-                pdbId + ProteinFileType.PDB
-        );
-    }
-
-    @ApiOperation(value = "Download MMCIF")
-    @RequestMapping(
-            path = "/mmcif/{pdbId}",
-            method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_OCTET_STREAM_VALUE
-    )
-    public ResponseEntity<Resource> downloadAsMmcif(@PathVariable String pdbId) {
-        return createResponseFile(
-                FileUtils.getMmcifFile(pdbId),
-                pdbId + ProteinFileType.MMCIF
-        );
-    }
-
-    @ApiOperation(value = "Download Motif")
-    @RequestMapping(
-            path = "/motif/{pdbId}",
+            value = "/motif",
             method = RequestMethod.POST,
+            consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_OCTET_STREAM_VALUE
     )
-    public ResponseEntity<Resource> downloadAsMotif(@PathVariable String pdbId) {
-        return createResponseFile(
-                FileUtils.getMotifFile(pdbId, null),
-                pdbId + ProteinFileType.MOTIF
-        );
-    }
-
-    private static ResponseEntity<Resource> createResponseFile(Resource file, String fileName) {
-        return ResponseEntity.ok()
-                .header(
-                        HttpHeaders.CONTENT_DISPOSITION,
-                        "attachment; filename=\"" + fileName + "\""
-                )
-                .body(file);
+    public ResponseEntity<Resource> createMotif(@RequestBody MakeMotifRequest makeMotifRequest) {
+        log.info("Received request to make a motif: " + makeMotifRequest);
+        return FileUtils.createMotifFile(makeMotifRequest);
     }
 }

--- a/src/main/java/org/moltimate/moltimatebackend/controller/MotifController.java
+++ b/src/main/java/org/moltimate/moltimatebackend/controller/MotifController.java
@@ -3,13 +3,18 @@ package org.moltimate.moltimatebackend.controller;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
+import org.moltimate.moltimatebackend.dto.MakeMotifRequest;
+import org.moltimate.moltimatebackend.exception.InvalidMotifException;
 import org.moltimate.moltimatebackend.model.Motif;
 import org.moltimate.moltimatebackend.service.MotifService;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidMotifException;
+import org.moltimate.moltimatebackend.util.FileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,8 +42,7 @@ public class MotifController {
             @ApiParam(name = "ecnumber", value = "Filter motifs by EC number. If 'ecnumber' is empty return all motifs")
             @RequestParam(name = "ecnumber", required = false) Optional<String> ecNumber,
             @ApiParam(name = "page", value = "Page number", defaultValue = "0")
-            @RequestParam(name = "page", required = false, defaultValue = "0") int pageNumber)
-    {
+            @RequestParam(name = "page", required = false, defaultValue = "0") int pageNumber) {
         return ResponseEntity.ok(motifService.queryByEcNumber(ecNumber.orElse(null), pageNumber));
     }
 
@@ -49,8 +53,7 @@ public class MotifController {
     @RequestMapping(value = "/{pdbId}", method = RequestMethod.GET)
     public ResponseEntity<Motif> findMotifByPdbId(
             @ApiParam(name = "pdbId", value = "PDB id of motif")
-            @PathVariable(name = "pdbId") String pdbId)
-    {
+            @PathVariable(name = "pdbId") String pdbId) {
         Motif motif = motifService.queryByPdbId(pdbId.toLowerCase());
         if (motif != null) {
             return ResponseEntity.ok(motif);

--- a/src/main/java/org/moltimate/moltimatebackend/dto/ActiveSiteAlignmentRequest.java
+++ b/src/main/java/org/moltimate/moltimatebackend/dto/ActiveSiteAlignmentRequest.java
@@ -38,20 +38,21 @@ public class ActiveSiteAlignmentRequest {
 
     public List<Motif> extractCustomMotifsFromFiles() {
         return customMotifs.stream()
-                .map(FileUtils::getMotifFromFile)
+                .map(FileUtils::readMotifFile)
                 .filter(Objects::nonNull)
+                .map(MotifFile::getMotif)
                 .collect(Collectors.toList());
     }
 
     public Map<Motif, Structure> extractCustomMotifMapFromFiles() {
         Map<Motif, Structure> results = new HashMap<>();
-        for (MultipartFile file : customMotifs) {
-            Motif _customMotif = FileUtils.getMotifFromFile(file);
-            Structure _customStructure = FileUtils.structureFromFile(file);
-            if (_customMotif != null && _customStructure != null) {
-                results.put(_customMotif, _customStructure);
+        customMotifs.forEach(customMotif -> {
+            MotifFile motifFile = FileUtils.readMotifFile(customMotif);
+            if (motifFile.getMotif() != null && motifFile.getStructure() != null) {
+                results.put(motifFile.getMotif(), motifFile.getStructure());
             }
-        }
+        });
+
         return results;
     }
 

--- a/src/main/java/org/moltimate/moltimatebackend/dto/MakeMotifRequest.java
+++ b/src/main/java/org/moltimate/moltimatebackend/dto/MakeMotifRequest.java
@@ -1,0 +1,18 @@
+package org.moltimate.moltimatebackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.moltimate.moltimatebackend.model.Residue;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MakeMotifRequest {
+
+    String pdbId;
+    String ecNumber;
+    List<Residue> activeSiteResidues;
+}

--- a/src/main/java/org/moltimate/moltimatebackend/dto/MotifFile.java
+++ b/src/main/java/org/moltimate/moltimatebackend/dto/MotifFile.java
@@ -1,0 +1,14 @@
+package org.moltimate.moltimatebackend.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import org.biojava.nbio.structure.Structure;
+import org.moltimate.moltimatebackend.model.Motif;
+
+@Data
+@Builder
+public class MotifFile {
+
+    Structure structure;
+    Motif motif;
+}

--- a/src/main/java/org/moltimate/moltimatebackend/dto/MotifTestRequest.java
+++ b/src/main/java/org/moltimate/moltimatebackend/dto/MotifTestRequest.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 import org.biojava.nbio.structure.Structure;
 import org.moltimate.moltimatebackend.util.FileUtils;
 import org.moltimate.moltimatebackend.util.ProteinUtils;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidPdbIdException;
+import org.moltimate.moltimatebackend.exception.InvalidPdbIdException;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ public class MotifTestRequest {
             }
             throw new InvalidPdbIdException(pdbId);
         }
-        return FileUtils.structureFromFile(customMotifStructure);
+        return FileUtils.getStructureFromFile(customMotifStructure);
     }
 
     public int getPrecisionFactor() {
@@ -70,7 +70,7 @@ public class MotifTestRequest {
 
     public List<Structure> extractCustomStructuresFromFiles() {
         return customStructures.stream()
-                .map(FileUtils::structureFromFile)
+                .map(FileUtils::getStructureFromFile)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/org/moltimate/moltimatebackend/dto/PdbQueryResponse.java
+++ b/src/main/java/org/moltimate/moltimatebackend/dto/PdbQueryResponse.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.biojava.nbio.structure.Structure;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidPdbIdException;
+import org.moltimate.moltimatebackend.exception.InvalidPdbIdException;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/moltimate/moltimatebackend/exception/InvalidEcNumberException.java
+++ b/src/main/java/org/moltimate/moltimatebackend/exception/InvalidEcNumberException.java
@@ -1,4 +1,4 @@
-package org.moltimate.moltimatebackend.validation.exceptions;
+package org.moltimate.moltimatebackend.exception;
 
 public class InvalidEcNumberException extends RuntimeException {
     public InvalidEcNumberException(String ecNumber) {

--- a/src/main/java/org/moltimate/moltimatebackend/exception/InvalidFileException.java
+++ b/src/main/java/org/moltimate/moltimatebackend/exception/InvalidFileException.java
@@ -1,4 +1,4 @@
-package org.moltimate.moltimatebackend.validation.exceptions;
+package org.moltimate.moltimatebackend.exception;
 
 public class InvalidFileException extends RuntimeException {
     public InvalidFileException(String errorMessage) {

--- a/src/main/java/org/moltimate/moltimatebackend/exception/InvalidMotifException.java
+++ b/src/main/java/org/moltimate/moltimatebackend/exception/InvalidMotifException.java
@@ -1,4 +1,4 @@
-package org.moltimate.moltimatebackend.validation.exceptions;
+package org.moltimate.moltimatebackend.exception;
 
 import java.util.List;
 

--- a/src/main/java/org/moltimate/moltimatebackend/exception/InvalidPdbIdException.java
+++ b/src/main/java/org/moltimate/moltimatebackend/exception/InvalidPdbIdException.java
@@ -1,4 +1,4 @@
-package org.moltimate.moltimatebackend.validation.exceptions;
+package org.moltimate.moltimatebackend.exception;
 
 import java.util.List;
 

--- a/src/main/java/org/moltimate/moltimatebackend/exception/MotifFileParseException.java
+++ b/src/main/java/org/moltimate/moltimatebackend/exception/MotifFileParseException.java
@@ -1,0 +1,10 @@
+package org.moltimate.moltimatebackend.exception;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class MotifFileParseException extends RuntimeException {
+
+    public MotifFileParseException(MultipartFile file) {
+        super("Cannot parse custom motif with filename: " + file.getOriginalFilename());
+    }
+}

--- a/src/main/java/org/moltimate/moltimatebackend/repository/MotifRepository.java
+++ b/src/main/java/org/moltimate/moltimatebackend/repository/MotifRepository.java
@@ -1,13 +1,10 @@
 package org.moltimate.moltimatebackend.repository;
 
 import org.moltimate.moltimatebackend.model.Motif;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Component;
 
-@Component
 public interface MotifRepository extends JpaRepository<Motif, String> {
 
     Motif findByPdbId(String pdbId);

--- a/src/main/java/org/moltimate/moltimatebackend/repository/ResidueQuerySetRepository.java
+++ b/src/main/java/org/moltimate/moltimatebackend/repository/ResidueQuerySetRepository.java
@@ -2,8 +2,6 @@ package org.moltimate.moltimatebackend.repository;
 
 import org.moltimate.moltimatebackend.model.ResidueQuerySet;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Component;
 
-@Component
 public interface ResidueQuerySetRepository extends JpaRepository<ResidueQuerySet, Long> {
 }

--- a/src/main/java/org/moltimate/moltimatebackend/service/MotifService.java
+++ b/src/main/java/org/moltimate/moltimatebackend/service/MotifService.java
@@ -11,6 +11,8 @@ import org.moltimate.moltimatebackend.model.Residue;
 import org.moltimate.moltimatebackend.model.ResidueQuerySet;
 import org.moltimate.moltimatebackend.repository.MotifRepository;
 import org.moltimate.moltimatebackend.repository.ResidueQuerySetRepository;
+import org.moltimate.moltimatebackend.util.ActiveSiteUtils;
+import org.moltimate.moltimatebackend.util.MotifUtils;
 import org.moltimate.moltimatebackend.util.ProteinUtils;
 import org.moltimate.moltimatebackend.util.StructureUtils;
 import org.moltimate.moltimatebackend.validation.EcNumberValidator;
@@ -41,12 +43,6 @@ public class MotifService {
 
     @Autowired
     private ResidueQuerySetRepository residueQuerySetRepository;
-
-    @Autowired
-    private ActiveSiteService activeSiteService;
-
-    @Autowired
-    private MotifService motifService;
 
     /**
      * Saves a new Motif to the database.
@@ -109,28 +105,10 @@ public class MotifService {
                 "unknown", ecNumber, PageRequest.of(pageNumber, MOTIF_BATCH_SIZE));
     }
 
-    public Motif generateMotif(String pdbId, String ecNumber, Structure structure, List<Residue> residues) {
-        for (Residue res : residues) {
-            Group group = StructureUtils.getResidue(
-                    structure, res.getResidueName(), res.getResidueId());
-            assert group != null;
-            res.setResidueChainName(group.getResidueNumber().getChainName());
-            res.setResidueAltLoc(Residue.getAltLocFromGroup(group));
-        }
-        return Motif.builder()
-                .pdbId(pdbId)
-                .activeSiteResidues(residues)
-                .ecNumber(ecNumber)
-                .selectionQueries(generateSelectionQueries(structure, residues))
-                .build();
-
-    }
-
     /**
      * Delete all motifs and their residue query sets
      */
     public void deleteAllAndFlush() {
-        //TODO: figure out why this breaks
 //        motifRepository.deleteAll();
 //        motifRepository.flush();
 //        residueQuerySetRepository.deleteAll();
@@ -138,13 +116,12 @@ public class MotifService {
     }
 
     // TODO: Pessimistic lock the motifs table until update is finished
-    // TODO: Pessimistic lock the motifs table until update is finished
     public Integer updateMotifs() {
         log.info("Updating Motif database");
-        List<ActiveSite> activeSites = activeSiteService.getActiveSites();
+        List<ActiveSite> activeSites = ActiveSiteUtils.getActiveSites();
 
         log.info("Deleting and flushing Motif database");
-//        motifService.deleteAllAndFlush();
+//        deleteAllAndFlush();
 
         log.info("Saving " + activeSites.size() + " new motifs");
         AtomicInteger motifsSaved = new AtomicInteger(0);
@@ -157,8 +134,8 @@ public class MotifService {
                         Structure structure = ProteinUtils.queryPdb(pdbId);
                         String ecNumber = StructureUtils.ecNumber(structure);
 
-                        Motif motif = generateMotif(pdbId, ecNumber, structure, residues);
-                        motifService.saveMotif(motif);
+                        Motif motif = MotifUtils.generateMotif(pdbId, ecNumber, structure, residues);
+                        saveMotif(motif);
                         motifsSaved.incrementAndGet();
                     } catch (Exception e) {
                         e.printStackTrace();
@@ -169,67 +146,5 @@ public class MotifService {
         log.info("Failed to save " + failedPdbIds.size() + " motifs to the database: " + failedPdbIds.toString());
         log.info("Finished saving " + motifsSaved.get() + " motifs to the database");
         return motifsSaved.get();
-    }
-
-    /**
-     * Generate a map where keys are PDB IDs and values are ResidueQuerySets
-     *
-     * @param structure          Structure (protein) to generate selection queries for
-     * @param activeSiteResidues List of active site Residue objects for this protein
-     * @return
-     */
-    private Map<String, ResidueQuerySet> generateSelectionQueries(Structure structure, List<Residue> activeSiteResidues) {
-        // Remove unwanted atoms from each residue's list of atoms
-        Map<Residue, List<Atom>> filteredResidueAtoms = new HashMap<>();
-        activeSiteResidues.forEach(residue -> {
-            Group group = StructureUtils.getResidue(structure, residue.getResidueName(), residue.getResidueId());
-            List<Atom> groupAtoms = group.getAtoms();
-            Atom firstCbAtom = groupAtoms.stream()
-                    .filter(atom -> atom.getName()
-                            .equals("CB"))
-                    .findFirst()
-                    .orElse(groupAtoms.get(1));
-            if (residue.getResidueName()
-                    .equalsIgnoreCase("ALA")) {
-                firstCbAtom = groupAtoms.get(1);
-            }
-            List<Atom> filteredAtoms = groupAtoms.subList(groupAtoms.indexOf(firstCbAtom), groupAtoms.size());
-            filteredAtoms = filteredAtoms.stream()
-                    .filter(atom -> !atom.getName()
-                            .contains("H"))
-                    .collect(Collectors.toList());
-            filteredResidueAtoms.put(residue, filteredAtoms);
-        });
-
-        // Compare every filtered atom in each residue to every other filtered atom in every other residue of this protein
-        Map<String, ResidueQuerySet> selectionQueries = new HashMap<>();
-        filteredResidueAtoms.forEach((residue, filteredAtoms) -> {
-            List<MotifSelection> motifSelections = new ArrayList<>();
-            filteredResidueAtoms.forEach((compareResidue, compareFilteredAtoms) -> {
-                if (residue == compareResidue) {
-                    return; // Do not compare a residue to itself
-                }
-
-                filteredAtoms.forEach(atom -> {
-                    compareFilteredAtoms.forEach(compareAtom -> {
-                        MotifSelection motifSelection = MotifSelection.builder()
-                                .atomType1(atom.getName())
-                                .atomType2(compareAtom.getName())
-                                .residueName1(atom.getGroup()
-                                                      .getChemComp()
-                                                      .getThree_letter_code())
-                                .residueName2(compareAtom.getGroup()
-                                                      .getChemComp()
-                                                      .getThree_letter_code())
-                                .distance(StructureUtils.rmsd(atom, compareAtom) + 2)
-                                .build();
-                        motifSelections.add(motifSelection);
-                    });
-                });
-            });
-            selectionQueries.put(residue.getIdentifier(), new ResidueQuerySet(motifSelections));
-        });
-
-        return selectionQueries;
     }
 }

--- a/src/main/java/org/moltimate/moltimatebackend/service/MotifTestService.java
+++ b/src/main/java/org/moltimate/moltimatebackend/service/MotifTestService.java
@@ -9,6 +9,7 @@ import org.moltimate.moltimatebackend.dto.PdbQueryResponse;
 import org.moltimate.moltimatebackend.model.Alignment;
 import org.moltimate.moltimatebackend.model.Motif;
 import org.moltimate.moltimatebackend.model.Residue;
+import org.moltimate.moltimatebackend.util.MotifUtils;
 import org.moltimate.moltimatebackend.util.PdbXmlClient;
 import org.moltimate.moltimatebackend.util.ProteinUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,7 @@ public class MotifTestService {
         String motifEcNumber = motifTestRequest.getEcNumber();
         Structure motifStructure = motifTestRequest.motifStructure();
         List<Residue> motifResidues = parseResidueEntries(motifTestRequest.getActiveSiteResidues());
-        Motif testMotif = motifService.generateMotif(motifPdbId, motifEcNumber, motifStructure, motifResidues);
+        Motif testMotif = MotifUtils.generateMotif(motifPdbId, motifEcNumber, motifStructure, motifResidues);
 
         List<Structure> structureList = new ArrayList<>();
         List<String> failedIds = new ArrayList<>();

--- a/src/main/java/org/moltimate/moltimatebackend/util/ActiveSiteUtils.java
+++ b/src/main/java/org/moltimate/moltimatebackend/util/ActiveSiteUtils.java
@@ -1,12 +1,10 @@
-package org.moltimate.moltimatebackend.service;
+package org.moltimate.moltimatebackend.util;
 
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
-import lombok.extern.slf4j.Slf4j;
 import org.moltimate.moltimatebackend.model.ActiveSite;
 import org.moltimate.moltimatebackend.model.Residue;
 import org.springframework.core.io.FileUrlResource;
-import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -19,23 +17,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Service used to query for or create active site Residues. Also provides the functionality to update our database's
- * active site table.
- */
-@Service
-@Slf4j
-public class ActiveSiteService {
+public class ActiveSiteUtils {
 
     //TODO: don't make web requests for these, use the local files.
     private static final String PROMOL_CSV_URL = "https://raw.githubusercontent.com/moltimate/moltimate-backend/master/src/main/resources/motifdata/promol_active_sites.csv";
     private static final String CSA_CSV_URL = "https://raw.githubusercontent.com/moltimate/moltimate-backend/master/src/main/resources/motifdata/csa_curated_data.csv";
-//    private static final String CSA_CSV_URL = "https://www.ebi.ac.uk/thornton-srv/m-csa/media/flat_files/csa_curated_data.csv";
 
     /**
      * Returns a list of protein active sites from known sources of truth
      */
-    public List<ActiveSite> getActiveSites() {
+    public static List<ActiveSite> getActiveSites() {
         return dedupeActiveSites(Arrays.asList(
                 getCsaActiveSites(),
                 getPromolActiveSites()
@@ -49,7 +40,7 @@ public class ActiveSiteService {
      * @param activeSiteLists Ordered list of active site lists
      * @return List of distinct active sites from all of the provided active site lists
      */
-    private List<ActiveSite> dedupeActiveSites(List<List<ActiveSite>> activeSiteLists) {
+    private static List<ActiveSite> dedupeActiveSites(List<List<ActiveSite>> activeSiteLists) {
         Map<String, Boolean> pdbIdSeen = new HashMap<>();
         List<ActiveSite> distinctActiveSites = new ArrayList<>();
 
@@ -75,7 +66,7 @@ public class ActiveSiteService {
      *
      * @return A list of ActiveSites
      */
-    private List<ActiveSite> getCsaActiveSites() {
+    private static List<ActiveSite> getCsaActiveSites() {
         try {
             Reader reader = new InputStreamReader(new FileUrlResource(new URL(CSA_CSV_URL)).getInputStream());
             CSVReader csvReader = new CSVReaderBuilder(reader).withSkipLines(1)
@@ -100,7 +91,7 @@ public class ActiveSiteService {
      *
      * @return A list of ActiveSites
      */
-    private List<ActiveSite> getPromolActiveSites() {
+    private static List<ActiveSite> getPromolActiveSites() {
         try {
             Reader reader = new InputStreamReader(new FileUrlResource(new URL(PROMOL_CSV_URL)).getInputStream());
             CSVReader csvReader = new CSVReaderBuilder(reader).withSkipLines(1)
@@ -137,7 +128,7 @@ public class ActiveSiteService {
     /**
      * Reads the next protein's active site residues from the Catalytic Site Atlas curated data file.
      */
-    private ActiveSite readNextCsaActiveSite(CSVReader csvReader) throws IOException {
+    private static ActiveSite readNextCsaActiveSite(CSVReader csvReader) throws IOException {
         List<Residue> activeSiteResidues = new ArrayList<>();
 
         String[] residueEntry;

--- a/src/main/java/org/moltimate/moltimatebackend/util/FileUtils.java
+++ b/src/main/java/org/moltimate/moltimatebackend/util/FileUtils.java
@@ -90,6 +90,26 @@ public class FileUtils {
         return createResponseFile(motifFile, pdbId, ProteinFileType.MOTIF);
     }
 
+    public static ResponseEntity<Resource> createMotifFile(String pdbId, String ecNumber, List<Residue> activeSiteResidues, Structure structure) {
+        String mmcifFile = structure.toPDB();
+        List<String> residueStrings = activeSiteResidues.stream()
+                .map(residue -> String.format(
+                        "%s %s %s",
+                        residue.getResidueName(),
+                        residue.getResidueId(),
+                        residue.getResidueChainName()
+                     )
+                )
+                .collect(Collectors.toList());
+
+        String motifFileFooter = MOTIF_DATA_SEPARATOR
+                + String.format("%s,%s,", pdbId, ecNumber)
+                + String.join(",", residueStrings);
+
+        Resource motifFile = new ByteArrayResource((mmcifFile + motifFileFooter).getBytes());
+        return createResponseFile(motifFile, pdbId, ProteinFileType.MOTIF);
+    }
+
     public static Structure getStructureFromFile(MultipartFile file) {
         return readMotifFile(file).getStructure();
     }

--- a/src/main/java/org/moltimate/moltimatebackend/util/FileUtils.java
+++ b/src/main/java/org/moltimate/moltimatebackend/util/FileUtils.java
@@ -71,7 +71,7 @@ public class FileUtils {
     }
 
     public static ResponseEntity<Resource> createMotifFile(String pdbId, String ecNumber, List<Residue> activeSiteResidues) {
-        String mmcifFile = ProteinUtils.queryPdb(pdbId).toPDB();
+        String pdbFile = ProteinUtils.queryPdb(pdbId).toPDB();
         List<String> residueStrings = activeSiteResidues.stream()
                 .map(residue -> String.format(
                         "%s %s %s",
@@ -86,12 +86,12 @@ public class FileUtils {
                 + String.format("%s,%s,", pdbId, ecNumber)
                 + String.join(",", residueStrings);
 
-        Resource motifFile = new ByteArrayResource((mmcifFile + motifFileFooter).getBytes());
+        Resource motifFile = new ByteArrayResource((pdbFile + motifFileFooter).getBytes());
         return createResponseFile(motifFile, pdbId, ProteinFileType.MOTIF);
     }
 
     public static ResponseEntity<Resource> createMotifFile(String pdbId, String ecNumber, List<Residue> activeSiteResidues, Structure structure) {
-        String mmcifFile = structure.toPDB();
+        String pdbFile = structure.toPDB();
         List<String> residueStrings = activeSiteResidues.stream()
                 .map(residue -> String.format(
                         "%s %s %s",
@@ -106,7 +106,7 @@ public class FileUtils {
                 + String.format("%s,%s,", pdbId, ecNumber)
                 + String.join(",", residueStrings);
 
-        Resource motifFile = new ByteArrayResource((mmcifFile + motifFileFooter).getBytes());
+        Resource motifFile = new ByteArrayResource((pdbFile + motifFileFooter).getBytes());
         return createResponseFile(motifFile, pdbId, ProteinFileType.MOTIF);
     }
 

--- a/src/main/java/org/moltimate/moltimatebackend/util/FileUtils.java
+++ b/src/main/java/org/moltimate/moltimatebackend/util/FileUtils.java
@@ -1,54 +1,159 @@
 package org.moltimate.moltimatebackend.util;
 
 import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.io.FileConvert;
 import org.biojava.nbio.structure.io.MMCIFFileReader;
 import org.biojava.nbio.structure.io.PDBFileReader;
+import org.moltimate.moltimatebackend.dto.MakeMotifRequest;
+import org.moltimate.moltimatebackend.dto.MotifFile;
+import org.moltimate.moltimatebackend.exception.InvalidFileException;
+import org.moltimate.moltimatebackend.exception.MotifFileParseException;
 import org.moltimate.moltimatebackend.model.Motif;
 import org.moltimate.moltimatebackend.model.Residue;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidFileException;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidPdbIdException;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class FileUtils {
 
     private static final PDBFileReader PDB_FILE_READER = new PDBFileReader();
     private static final MMCIFFileReader MMCIF_FILE_READER = new MMCIFFileReader();
+    private static final String MOTIF_DATA_SEPARATOR = "MOLTIMATE-DATA\n";
+
+    private static enum ProteinFileType {
+        PDB(".pdb"),
+        MMCIF(".cif"),
+        MOTIF(".motif");
+
+        private String fileExtension;
+
+        ProteinFileType(String fileExtension) {
+            this.fileExtension = fileExtension;
+        }
+
+        @Override
+        public String toString() {
+            return fileExtension;
+        }
+
+        public static List<String> getValidFileTypes() {
+            return Arrays.stream(ProteinFileType.values())
+                    .map(proteinFileType -> proteinFileType.toString())
+                    .collect(Collectors.toList());
+        }
+    }
+
+    public static ResponseEntity<Resource> createPdbFile(String pdbId) {
+        Resource pdbFile = new ByteArrayResource(ProteinUtils.queryPdb(pdbId)
+                                                         .toPDB()
+                                                         .getBytes());
+        return createResponseFile(pdbFile, pdbId, ProteinFileType.PDB);
+    }
+
+    public static ResponseEntity<Resource> createMmcifFile(String pdbId) {
+        Resource mmcifFile = new ByteArrayResource(ProteinUtils.queryPdb(pdbId)
+                                                           .toMMCIF()
+                                                           .getBytes());
+        return createResponseFile(mmcifFile, pdbId, ProteinFileType.MMCIF);
+    }
+
+    public static ResponseEntity<Resource> createMotifFile(MakeMotifRequest request) {
+        return createMotifFile(request.getPdbId(), request.getEcNumber(), request.getActiveSiteResidues());
+    }
+
+    public static ResponseEntity<Resource> createMotifFile(String pdbId, String ecNumber, List<Residue> activeSiteResidues) {
+        String mmcifFile = ProteinUtils.queryPdb(pdbId).toPDB();
+        List<String> residueStrings = activeSiteResidues.stream()
+                .map(residue -> String.format(
+                        "%s %s %s",
+                        residue.getResidueName(),
+                        residue.getResidueId(),
+                        residue.getResidueChainName()
+                     )
+                )
+                .collect(Collectors.toList());
+
+        String motifFileFooter = MOTIF_DATA_SEPARATOR
+                + String.format("%s,%s,", pdbId, ecNumber)
+                + String.join(",", residueStrings);
+
+        Resource motifFile = new ByteArrayResource((mmcifFile + motifFileFooter).getBytes());
+        return createResponseFile(motifFile, pdbId, ProteinFileType.MOTIF);
+    }
+
+    public static Structure getStructureFromFile(MultipartFile file) {
+        return readMotifFile(file).getStructure();
+    }
 
     public static Motif getMotifFromFile(MultipartFile file) {
-        // TODO: Read motif metadata from file and process it
-        return null;
+        return readMotifFile(file).getMotif();
     }
 
-    public static Resource getPdbFile(String pdbId) {
-        return new ByteArrayResource(ProteinUtils.queryPdb(pdbId)
-                                             .toPDB()
-                                             .getBytes());
-    }
-
-    public static Resource getMmcifFile(String pdbId) {
-        return new ByteArrayResource(ProteinUtils.queryPdb(pdbId)
-                                             .toMMCIF()
-                                             .getBytes());
-    }
-
-    public static Resource getMotifFile(String pdbId, List<Residue> activeSiteResidues) {
-        return null;
-    }
-
-    public static Structure structureFromFile(MultipartFile file) {
+    public static MotifFile readMotifFile(MultipartFile file) {
         try {
-            return PDB_FILE_READER.getStructure(file.getInputStream());
+            String[] partitions = new String(file.getBytes()).split(MOTIF_DATA_SEPARATOR);
+            return MotifFile.builder()
+                    .structure(getStructureFromString(partitions[0]))
+                    .motif(getMotifFromString(partitions[1]))
+                    .build();
+        } catch (InvalidFileException e) {
+            throw e;
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new MotifFileParseException(file);
+        }
+    }
+
+    private static Structure getStructureFromString(String string) {
+        try {
+            return PDB_FILE_READER.getStructure(new ByteArrayInputStream(string.getBytes()));
         } catch (IOException pdbReaderError) {
             try {
-                return MMCIF_FILE_READER.getStructure(file.getInputStream());
+                return MMCIF_FILE_READER.getStructure(new ByteArrayInputStream(string.getBytes()));
             } catch (IOException ignored) {
-                throw new InvalidFileException("Could not parse given file\nPlease check the file to make sure it is a valid PDB or MMCIF file");
+                throw new InvalidFileException(
+                        "Could not parse given file\nPlease check the file to make sure it is a valid format: " + ProteinFileType.getValidFileTypes());
             }
         }
+    }
+
+    private static Motif getMotifFromString(String string) {
+        String[] motifData = string.split(",");
+
+        List<Residue> activeSiteResidues = new ArrayList<>();
+        for (int i = 2; i < motifData.length; i++) {
+            String[] residueData = motifData[i].split(" ");
+            activeSiteResidues.add(Residue.builder()
+                                           .residueName(residueData[0])
+                                           .residueId(residueData[1])
+                                           .residueChainName(residueData[2])
+                                           .build());
+        }
+
+        String pdbId = motifData[0];
+        String ecNumber = motifData[1];
+        return MotifUtils.generateMotif(pdbId, ecNumber, ProteinUtils.queryPdb(pdbId), activeSiteResidues);
+    }
+
+    private static ResponseEntity<Resource> createResponseFile(Resource file, String fileName, ProteinFileType proteinFileType) {
+        return createResponseFile(file, fileName, proteinFileType.toString());
+    }
+
+    private static ResponseEntity<Resource> createResponseFile(Resource file, String fileName, String fileExtension) {
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        "attachment; filename=\"" + fileName + fileExtension + "\""
+                )
+                .body(file);
     }
 }

--- a/src/main/java/org/moltimate/moltimatebackend/util/FileUtils.java
+++ b/src/main/java/org/moltimate/moltimatebackend/util/FileUtils.java
@@ -1,7 +1,6 @@
 package org.moltimate.moltimatebackend.util;
 
 import org.biojava.nbio.structure.Structure;
-import org.biojava.nbio.structure.io.FileConvert;
 import org.biojava.nbio.structure.io.MMCIFFileReader;
 import org.biojava.nbio.structure.io.PDBFileReader;
 import org.moltimate.moltimatebackend.dto.MakeMotifRequest;
@@ -71,23 +70,7 @@ public class FileUtils {
     }
 
     public static ResponseEntity<Resource> createMotifFile(String pdbId, String ecNumber, List<Residue> activeSiteResidues) {
-        String pdbFile = ProteinUtils.queryPdb(pdbId).toPDB();
-        List<String> residueStrings = activeSiteResidues.stream()
-                .map(residue -> String.format(
-                        "%s %s %s",
-                        residue.getResidueName(),
-                        residue.getResidueId(),
-                        residue.getResidueChainName()
-                     )
-                )
-                .collect(Collectors.toList());
-
-        String motifFileFooter = MOTIF_DATA_SEPARATOR
-                + String.format("%s,%s,", pdbId, ecNumber)
-                + String.join(",", residueStrings);
-
-        Resource motifFile = new ByteArrayResource((pdbFile + motifFileFooter).getBytes());
-        return createResponseFile(motifFile, pdbId, ProteinFileType.MOTIF);
+        return createMotifFile(pdbId, ecNumber, activeSiteResidues, ProteinUtils.queryPdb(pdbId));
     }
 
     public static ResponseEntity<Resource> createMotifFile(String pdbId, String ecNumber, List<Residue> activeSiteResidues, Structure structure) {

--- a/src/main/java/org/moltimate/moltimatebackend/util/MotifUtils.java
+++ b/src/main/java/org/moltimate/moltimatebackend/util/MotifUtils.java
@@ -1,0 +1,97 @@
+package org.moltimate.moltimatebackend.util;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.Structure;
+import org.moltimate.moltimatebackend.model.Motif;
+import org.moltimate.moltimatebackend.model.MotifSelection;
+import org.moltimate.moltimatebackend.model.Residue;
+import org.moltimate.moltimatebackend.model.ResidueQuerySet;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MotifUtils {
+
+    public static Motif generateMotif(String pdbId, String ecNumber, Structure structure, List<Residue> residues) {
+        for (Residue res : residues) {
+            Group group = StructureUtils.getResidue(
+                    structure, res.getResidueName(), res.getResidueId());
+            assert group != null;
+            res.setResidueChainName(group.getResidueNumber().getChainName());
+            res.setResidueAltLoc(Residue.getAltLocFromGroup(group));
+        }
+        return Motif.builder()
+                .pdbId(pdbId)
+                .activeSiteResidues(residues)
+                .ecNumber(ecNumber)
+                .selectionQueries(generateSelectionQueries(structure, residues))
+                .build();
+
+    }
+
+    /**
+     * Generate a map where keys are PDB IDs and values are ResidueQuerySets
+     *
+     * @param structure          Structure (protein) to generate selection queries for
+     * @param activeSiteResidues List of active site Residue objects for this protein
+     * @return
+     */
+    private static Map<String, ResidueQuerySet> generateSelectionQueries(Structure structure, List<Residue> activeSiteResidues) {
+        // Remove unwanted atoms from each residue's list of atoms
+        Map<Residue, List<Atom>> filteredResidueAtoms = new HashMap<>();
+        activeSiteResidues.forEach(residue -> {
+            Group group = StructureUtils.getResidue(structure, residue.getResidueName(), residue.getResidueId());
+            List<Atom> groupAtoms = group.getAtoms();
+            Atom firstCbAtom = groupAtoms.stream()
+                    .filter(atom -> atom.getName()
+                            .equals("CB"))
+                    .findFirst()
+                    .orElse(groupAtoms.get(1));
+            if (residue.getResidueName()
+                    .equalsIgnoreCase("ALA")) {
+                firstCbAtom = groupAtoms.get(1);
+            }
+            List<Atom> filteredAtoms = groupAtoms.subList(groupAtoms.indexOf(firstCbAtom), groupAtoms.size());
+            filteredAtoms = filteredAtoms.stream()
+                    .filter(atom -> !atom.getName()
+                            .contains("H"))
+                    .collect(Collectors.toList());
+            filteredResidueAtoms.put(residue, filteredAtoms);
+        });
+
+        // Compare every filtered atom in each residue to every other filtered atom in every other residue of this protein
+        Map<String, ResidueQuerySet> selectionQueries = new HashMap<>();
+        filteredResidueAtoms.forEach((residue, filteredAtoms) -> {
+            List<MotifSelection> motifSelections = new ArrayList<>();
+            filteredResidueAtoms.forEach((compareResidue, compareFilteredAtoms) -> {
+                if (residue == compareResidue) {
+                    return; // Do not compare a residue to itself
+                }
+
+                filteredAtoms.forEach(atom -> {
+                    compareFilteredAtoms.forEach(compareAtom -> {
+                        MotifSelection motifSelection = MotifSelection.builder()
+                                .atomType1(atom.getName())
+                                .atomType2(compareAtom.getName())
+                                .residueName1(atom.getGroup()
+                                                      .getChemComp()
+                                                      .getThree_letter_code())
+                                .residueName2(compareAtom.getGroup()
+                                                      .getChemComp()
+                                                      .getThree_letter_code())
+                                .distance(StructureUtils.rmsd(atom, compareAtom) + 2)
+                                .build();
+                        motifSelections.add(motifSelection);
+                    });
+                });
+            });
+            selectionQueries.put(residue.getIdentifier(), new ResidueQuerySet(motifSelections));
+        });
+
+        return selectionQueries;
+    }
+}

--- a/src/main/java/org/moltimate/moltimatebackend/util/ProteinUtils.java
+++ b/src/main/java/org/moltimate/moltimatebackend/util/ProteinUtils.java
@@ -5,7 +5,7 @@ import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.io.MMCIFFileReader;
 import org.biojava.nbio.structure.io.PDBFileReader;
 import org.moltimate.moltimatebackend.dto.PdbQueryResponse;
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidPdbIdException;
+import org.moltimate.moltimatebackend.exception.InvalidPdbIdException;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/main/java/org/moltimate/moltimatebackend/validation/EcNumberValidator.java
+++ b/src/main/java/org/moltimate/moltimatebackend/validation/EcNumberValidator.java
@@ -1,6 +1,6 @@
 package org.moltimate.moltimatebackend.validation;
 
-import org.moltimate.moltimatebackend.validation.exceptions.InvalidEcNumberException;
+import org.moltimate.moltimatebackend.exception.InvalidEcNumberException;
 
 public class EcNumberValidator {
 


### PR DESCRIPTION
This will add an endpoint, `/download/motif` which can download a custom motif file from a JSON payload of the following format:

```
{
	"pdbId": "1yph",
	"ecNumber": "3.4.14.21",
	"activeSiteResidues": [
		{
			"residueName": "His",
			"residueChainName": "C",
			"residueId": "57"
		},
		{
			"residueName": "Asp",
			"residueChainName": "C",
			"residueId": "102"
		},
		{
			"residueName": "Gly",
			"residueChainName": "E",
			"residueId": "193"
		},
		{
			"residueName": "Ser",
			"residueChainName": "E",
			"residueId": "195"
		},
		{
			"residueName": "Gly",
			"residueChainName": "E",
			"residueId": "196"
		}
	]
}
```

It also decodes these motif files when they're received by the backend.