### PR TITLE
MOL-10: Adding development CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,13 @@ install:
 script:
 - mvn -P prod test -B
 deploy:
-  provider: gae
+- provider: gae
   project: moltimate
   keyfile: client-secret.json
   on: master
+- provider: gae
+  project: moltimate
+  version: development
+  no_promote: true
+  keyfile: client-secret.json
+  on: dev

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <configuration>


### PR DESCRIPTION
## Description
Added a deploy path for travis-ci to build the dev branch and
deploy a new version to GCloud AppEngine without overwriting
the master instance.
Fixed version line for dependency in pom.xml

Let's see if this does the thing. 
