### PR TITLE
MOL-62: Added Macromolecule by ID for docking

### DIFF
--- a/src/main/java/org/moltimate/moltimatebackend/dto/request/DockingRequest.java
+++ b/src/main/java/org/moltimate/moltimatebackend/dto/request/DockingRequest.java
@@ -17,6 +17,7 @@ public class DockingRequest {
 	private MultipartFile macromolecule;
 	private MultipartFile ligand;
 	private String ligandID;
+	private String macromoleculeID;
 	private double center_x;
 	private double center_y;
 	private double center_z;

--- a/src/main/java/org/moltimate/moltimatebackend/service/LigandService.java
+++ b/src/main/java/org/moltimate/moltimatebackend/service/LigandService.java
@@ -61,21 +61,21 @@ public class LigandService {
      * Fetch the Ligand File needed for the supplied Docking Request
      * @param request
      */
-    public static MultipartFile fetchLigand(DockingRequest request) {
-        if (request.getLigandID() == null) {
+    public static MultipartFile fetchLigand(String ligandID) {
+        if (ligandID == null) {
             throw new InvalidFileException("Unable to fetch remote Ligand File: no ligandID provided");
         }
 
-        log.info("Fetching Ligand {} for Docking Request", request.getLigandID());
+        log.info("Fetching Ligand {} for Docking Request", ligandID);
 
         try {
-            URL fileLocation = new URL(String.format(DockingUtils.SDF_URL, request.getLigandID()));
+            URL fileLocation = new URL(String.format(DockingUtils.SDF_URL, ligandID));
             InputStream fileStream = fileLocation.openStream();
             byte[] file = new byte[fileStream.available()];
 
             fileStream.read(file);
 
-            return new InMemoryMultipartFile(request.getLigandID()+".sdf", file);
+            return new InMemoryMultipartFile(ligandID+".sdf", file);
         }
         catch (IOException e) {
             throw new InvalidFileException("Unable to fetch remote Ligand File");


### PR DESCRIPTION
Added macromoleculeID field to Docking Request, and added
fetchMacromolecule method to DockingService for getting the pdb file.
Also changed LigandService.fetchLigand to take only the ligandID, not
the whole request object.

### Description
<!--- Please explain the changes you made here. -->

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
