### PR TITLE
MOL-65: updateMotifs fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot.version>2.1.3.RELEASE</spring.boot.version>
+        <spring.boot.version>2.2.5.RELEASE</spring.boot.version>
         <spring.cloud.version>1.1.1.RELEASE</spring.cloud.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -40,6 +40,12 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
             <version>${spring.boot.version}</version>
             <scope>provided</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+            <version>5.2.5.RELEASE</version>
         </dependency>
 
         <dependency>
@@ -82,6 +88,12 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jpa</artifactId>
             <version>2.1.5.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+            <version>1.2.5.RELEASE</version>
         </dependency>
 
         <dependency>
@@ -146,7 +158,7 @@
         <dependency>
             <groupId>org.biojava</groupId>
             <artifactId>biojava-structure</artifactId>
-            <version>5.1.1</version>
+            <version>5.3.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/org/moltimate/moltimatebackend/config/DevConfiguration.java
+++ b/src/main/java/org/moltimate/moltimatebackend/config/DevConfiguration.java
@@ -2,10 +2,12 @@ package org.moltimate.moltimatebackend.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableRetry
 @Profile("dev")
 public class DevConfiguration implements WebMvcConfigurer {
 

--- a/src/main/java/org/moltimate/moltimatebackend/config/ProdConfiguration.java
+++ b/src/main/java/org/moltimate/moltimatebackend/config/ProdConfiguration.java
@@ -2,10 +2,12 @@ package org.moltimate.moltimatebackend.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableRetry
 @Profile("prod")
 public class ProdConfiguration implements WebMvcConfigurer {
 

--- a/src/main/java/org/moltimate/moltimatebackend/service/MotifService.java
+++ b/src/main/java/org/moltimate/moltimatebackend/service/MotifService.java
@@ -12,7 +12,6 @@ import org.moltimate.moltimatebackend.repository.ResidueQuerySetRepository;
 import org.moltimate.moltimatebackend.util.ActiveSiteUtils;
 import org.moltimate.moltimatebackend.util.MotifUtils;
 import org.moltimate.moltimatebackend.util.ProteinUtils;
-import org.moltimate.moltimatebackend.util.StructureUtils;
 import org.moltimate.moltimatebackend.validation.EcNumberValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -37,6 +36,9 @@ public class MotifService {
 
     @Autowired
     private MotifRepository motifRepository;
+
+    @Autowired
+    private LigandService ligandService;
 
     @Autowired
     private ResidueQuerySetRepository residueQuerySetRepository;
@@ -129,7 +131,7 @@ public class MotifService {
                     try {
                         List<Residue> residues = activeSite.getResidues();
                         Structure structure = ProteinUtils.queryPdb(pdbId);
-                        String ecNumber = StructureUtils.ecNumber(structure);
+                        String ecNumber = ligandService.getEcNumber(structure);
 
                         Motif motif = MotifUtils.generateMotif(pdbId, ecNumber, structure, residues);
                         saveMotif(motif);

--- a/src/main/java/org/moltimate/moltimatebackend/service/MotifTestService.java
+++ b/src/main/java/org/moltimate/moltimatebackend/service/MotifTestService.java
@@ -28,6 +28,9 @@ public class MotifTestService {
     @Autowired
     private AlignmentService alignmentService;
 
+    @Autowired
+    private LigandService ligandService;
+
     public MotifAlignmentResponse testMotifAlignment(MotifTestRequest motifTestRequest) {
         Structure motifStructure = motifTestRequest.motifStructure();
         MotifFile testMotifFile = MotifFile.builder()
@@ -93,7 +96,7 @@ public class MotifTestService {
             if (alignment != null) {
                 motifAlignmentResponse.addSuccessfulEntry(structure, alignment);
             } else {
-                motifAlignmentResponse.addFailedEntry(structure.getPDBCode(), StructureUtils.ecNumber(structure));
+                motifAlignmentResponse.addFailedEntry(structure.getPDBCode(), ligandService.getEcNumber(structure));
             }
         }
         return motifAlignmentResponse;


### PR DESCRIPTION
Updated biojava and spring dependencies to prevent arbitrary failures
Added retryable getEcNumber method to LigandService to avoid 429
errors on retrieving pdb information
Enabled Spring retryable in dev and prod profiles

Motif generation now fails only for those CSA entries that are
inconsistent with the PDB. This is caused by the .csv file we use
being outdated, and the M-CSA has announced they will not be
updating those files *ever*. An important task for next year's team
will be to utilize the residue API, rather than relying on the
files.

### Description
<!--- Please explain the changes you made here. -->

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
